### PR TITLE
This is to move management of TSC members and committee members to the governance repo

### DIFF
--- a/L3AF_Committee_Members.md
+++ b/L3AF_Committee_Members.md
@@ -2,6 +2,8 @@
 This page is the record of truth on the current L3AF representatives for the committees defined below.
 
 # L3AF Technical Steering Committee (TSC)
+[Information about the L3AF TSC](https://github.com/l3af-project/governance/blob/main/docs/L3AF_technical_charter.md)
+
 |Company Name | TSC Representative | TSC Alternate Representative | Role |
 |-------------|--------------------|------------------------------|------|
 | Walmart | Jason Niesz | Meni Hillel | TSC Member |

--- a/L3AF_Committee_Members.md
+++ b/L3AF_Committee_Members.md
@@ -1,0 +1,24 @@
+# Overview
+This page is the record of truth on the current L3AF representatives for the committees defined below.
+
+# L3AF Technical Steering Committee (TSC)
+|Company Name | TSC Representative | TSC Alternate Representative | Role |
+|-------------|--------------------|------------------------------|------|
+| Walmart | Jason Niesz | Meni Hillel | |
+| Walmart | Santhosh Fernandes | Kanthi Pavuluri | |
+| Microsoft | Dave Thaler | Steve Laughman | |
+| Wipro | Eric Tice | VM (Vicky) Brasseur | |
+
+# LFN Marketing Advisory Council (MAC)
+[Information about the MAC](https://wiki.lfnetworking.org/pages/viewpage.action?pageId=327912)
+
+| Company Name | Liaison |
+|--------------|--------------------|
+| Microsoft | Daniel Havey |
+
+# LFN Technical Advisory Council (TSC)
+[Information about the TSC ](https://wiki.lfnetworking.org/pages/viewpage.action?pageId=327908)
+
+| Company Name | Liaison |
+|--------------|--------------------|
+| Walmart | Santhosh Fernandes |

--- a/L3AF_Committee_Members.md
+++ b/L3AF_Committee_Members.md
@@ -4,21 +4,21 @@ This page is the record of truth on the current L3AF representatives for the com
 # L3AF Technical Steering Committee (TSC)
 |Company Name | TSC Representative | TSC Alternate Representative | Role |
 |-------------|--------------------|------------------------------|------|
-| Walmart | Jason Niesz | Meni Hillel | |
-| Walmart | Santhosh Fernandes | Kanthi Pavuluri | |
-| Microsoft | Dave Thaler | Steve Laughman | |
-| Wipro | Eric Tice | VM (Vicky) Brasseur | |
+| Walmart | Jason Niesz | Meni Hillel | TSC Member |
+| Walmart | Santhosh Fernandes | Kanthi Pavuluri | TSC Member |
+| Microsoft | Dave Thaler | Steve Laughman | TSC Member |
+| Wipro | Eric Tice | VM (Vicky) Brasseur | TSC Member |
 
 # LFN Marketing Advisory Council (MAC)
 [Information about the MAC](https://wiki.lfnetworking.org/pages/viewpage.action?pageId=327912)
 
 | Company Name | Liaison |
-|--------------|--------------------|
+|--------------|---------|
 | Microsoft | Daniel Havey |
 
 # LFN Technical Advisory Council (TSC)
 [Information about the TSC ](https://wiki.lfnetworking.org/pages/viewpage.action?pageId=327908)
 
 | Company Name | Liaison |
-|--------------|--------------------|
+|--------------|---------|
 | Walmart | Santhosh Fernandes |

--- a/L3AF_Committee_Members.md
+++ b/L3AF_Committee_Members.md
@@ -18,8 +18,8 @@ This page is the record of truth on the current L3AF representatives for the com
 |--------------|---------|
 | Microsoft | Daniel Havey |
 
-# LFN Technical Advisory Council (TSC)
-[Information about the TSC ](https://wiki.lfnetworking.org/pages/viewpage.action?pageId=327908)
+# LFN Technical Advisory Council (TAC)
+[Information about the TAC](https://wiki.lfnetworking.org/pages/viewpage.action?pageId=327908)
 
 | Company Name | Liaison |
 |--------------|---------|


### PR DESCRIPTION
Once this is approved and merged, I will update the [wiki](https://wiki.lfnetworking.org/pages/viewpage.action?pageId=62491327) to point to this file.