### PR TITLE
Update the codeowner list as proposed in the 8/8/2023 TSC.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,4 +8,4 @@
 # Unless a later match takes precedence, they will be requested for
 # review when someone opens a pull request.
 # Initial list: TSC as of March 2022 + VMB 
-* @vmbrasseur @jniesz @dthaler @erictice @sanfern @dalalkaran @binojrajan
+* @jniesz @dthaler @sanfern @dalalkaran @binojrajan


### PR DESCRIPTION
In this PR, Removing inactive codeowners from the list as proposed in the TSC meeting 8/8/2023.